### PR TITLE
Add cron script for periodic signal logging

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_BASE_URL=https://bitcoin-notification-api-production.up.railway.app

--- a/cron/evaluateAndLog.js
+++ b/cron/evaluateAndLog.js
@@ -1,0 +1,16 @@
+const { evaluateSignal } = require("../signalEvaluator");
+const axios = require("axios");
+require("dotenv").config();
+
+async function run() {
+  try {
+    const res = await axios.get(`${process.env.API_BASE_URL}/api/btc-indicators`);
+    const result = evaluateSignal(res.data);
+    console.log(`[SIGNAL] ${result.signal} - ${result.reason.join(", ")}`);
+  } catch (err) {
+    console.error("[ERROR] Failed to fetch indicators or evaluate signal", err.message);
+  }
+}
+
+run();
+setInterval(run, 15 * 60 * 1000); // every 15 minutes


### PR DESCRIPTION
## Summary
- fetch BTC indicators periodically and log evaluated signal
- include `.env` for API base URL

## Testing
- `npm test` *(fails: Missing script)*