### PR TITLE
Fix ESM imports for Railway build

### DIFF
--- a/cron/evaluateAndLog.js
+++ b/cron/evaluateAndLog.js
@@ -1,7 +1,8 @@
-const { evaluateSignal } = require("../signalEvaluator");
-const axios = require("axios");
-const { sendEmail } = require("../notifier");
-require("dotenv").config();
+import { evaluateSignal } from "../signalEvaluator.js";
+import axios from "axios";
+import { sendEmail } from "../notifier.js";
+import dotenv from "dotenv";
+dotenv.config();
 
 async function run() {
   try {

--- a/notifier.js
+++ b/notifier.js
@@ -1,5 +1,6 @@
-const nodemailer = require('nodemailer');
-require('dotenv').config();
+import nodemailer from 'nodemailer';
+import dotenv from 'dotenv';
+dotenv.config();
 
 function createTransporter() {
   if (!process.env.SENDGRID_API_KEY) {
@@ -43,4 +44,4 @@ async function sendEmail(subject, text) {
   }
 }
 
-module.exports = { sendEmail };
+export { sendEmail };

--- a/signalEvaluator.js
+++ b/signalEvaluator.js
@@ -139,4 +139,4 @@ function evaluateSignal(data) {
   return result;
 }
 
-module.exports = { evaluateSignal };
+export { evaluateSignal };


### PR DESCRIPTION
## Summary
- fix Railway build by converting helper scripts to ES module syntax

## Testing
- `node --check cron/evaluateAndLog.js`
- `node --check notifier.js`
- `node --check signalEvaluator.js`
