### PR TITLE
Add multi-asset monitoring and 4h cron

### DIFF
--- a/cron/evaluateAndLog.js
+++ b/cron/evaluateAndLog.js
@@ -5,18 +5,28 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const trackedAssets = [
+  { symbol: 'BTC/USD', name: 'Bitcoin' },
+  { symbol: 'SOL/USD', name: 'Solana' },
+  { symbol: 'XRP/USD', name: 'XRP' },
+  { symbol: 'ADA/USD', name: 'Cardano' }
+];
+
 async function run() {
-  try {
-    console.log(`[CRON] Running at ${new Date().toISOString()}`);
-    const res = await axios.get(`${process.env.API_BASE_URL}/api/btc-indicators`);
-    const result = evaluateSignal(res.data);
-    console.log(`[SIGNAL] ${result.signal} - ${result.reason.join(', ')}`);
-    if (['BUY', 'SELL'].includes(result.signal)) {
-      await sendEmail(`${result.signal} Signal`, result.reason.join('\n'));
-      console.log(`[EMAIL] Sent ${result.signal} notification`);
+  for (const asset of trackedAssets) {
+    try {
+      console.log(`[CRON] Checking ${asset.name} at ${new Date().toISOString()}`);
+      const url = `${process.env.API_BASE_URL}/api/btc-indicators?symbol=${encodeURIComponent(asset.symbol)}`;
+      const res = await axios.get(url);
+      const result = evaluateSignal(res.data);
+      console.log(`[SIGNAL][${asset.name}] ${result.signal} - ${result.reason.join(', ')}`);
+      if (['BUY', 'SELL'].includes(result.signal)) {
+        await sendEmail(`[${asset.name}] ${result.signal}`, result.reason.join('\n'));
+        console.log(`[EMAIL][${asset.name}] Sent ${result.signal} notification`);
+      }
+    } catch (error) {
+      console.error(`[CRON ERROR][${asset.name}] ${error.message}`);
     }
-  } catch (error) {
-    console.error(`[CRON ERROR] ${error.message}`);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -84,20 +84,22 @@ app.get('/api/btc-indicators', async (req, res) => {
       .json({ error: 'TWELVE_DATA_API_KEY is not configured' });
   }
 
+  const symbol = req.query.symbol || 'BTC/USD';
+
   const endpoints = {
-    rsi: 'https://api.twelvedata.com/rsi?symbol=BTC/USD&interval=1h&time_period=14&series_type=close',
-    macd: 'https://api.twelvedata.com/macd?symbol=BTC/USD&interval=1h&series_type=close',
-    ema20: 'https://api.twelvedata.com/ema?symbol=BTC/USD&interval=1h&time_period=20&series_type=close',
-    sma50: 'https://api.twelvedata.com/sma?symbol=BTC/USD&interval=1h&time_period=50&series_type=close',
-    bbands: 'https://api.twelvedata.com/bbands?symbol=BTC/USD&interval=1h&time_period=20&series_type=close&sd=2',
-    stochastic: 'https://api.twelvedata.com/stoch?symbol=BTC/USD&interval=1h',
-    adx: 'https://api.twelvedata.com/adx?symbol=BTC/USD&interval=1h&time_period=14',
-    cci: 'https://api.twelvedata.com/cci?symbol=BTC/USD&interval=1h&time_period=20&series_type=close'
+    rsi: `https://api.twelvedata.com/rsi?symbol=${symbol}&interval=1h&time_period=14&series_type=close`,
+    macd: `https://api.twelvedata.com/macd?symbol=${symbol}&interval=1h&series_type=close`,
+    ema20: `https://api.twelvedata.com/ema?symbol=${symbol}&interval=1h&time_period=20&series_type=close`,
+    sma50: `https://api.twelvedata.com/sma?symbol=${symbol}&interval=1h&time_period=50&series_type=close`,
+    bbands: `https://api.twelvedata.com/bbands?symbol=${symbol}&interval=1h&time_period=20&series_type=close&sd=2`,
+    stochastic: `https://api.twelvedata.com/stoch?symbol=${symbol}&interval=1h`,
+    adx: `https://api.twelvedata.com/adx?symbol=${symbol}&interval=1h&time_period=14`,
+    cci: `https://api.twelvedata.com/cci?symbol=${symbol}&interval=1h&time_period=20&series_type=close`
   };
 
   try {
     const requests = Object.entries(endpoints).map(([key, baseUrl]) =>
-      fetchWithCache(`${baseUrl}&apikey=${apiKey}`, key)
+      fetchWithCache(`${baseUrl}&apikey=${apiKey}`, `${symbol}-${key}`)
         .then((data) => ({ key, data }))
         .catch((error) => ({ key, error: error.message }))
     );
@@ -164,7 +166,7 @@ if (process.env.ENABLE_CRON === 'true') {
   evaluateSignalJob();
   setInterval(() => {
     evaluateSignalJob();
-  }, 15 * 60 * 1000);
+  }, 4 * 60 * 60 * 1000);
 
   setInterval(() => {
     console.log(`[DEBUG] App is alive at ${new Date().toISOString()}`);


### PR DESCRIPTION
## Summary
- monitor multiple assets in cron job
- update `/api/btc-indicators` to support `symbol` query param
- change cron schedule to every 4 hours

## Testing
- `node --check cron/evaluateAndLog.js`
- `node --check index.js`
- `npm start` *(fails: Cannot find package 'express')*