### PR TITLE
Switch data source to CryptoCompare

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 API_BASE_URL=https://bitcoin-notification-api-production.up.railway.app
+
+CRYPTOCOMPARE_API_KEY=your_key_here

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Copy this file to .env and provide your Twelve Data API key
-TWELVE_DATA_API_KEY=your_api_key_here
+# Copy this file to .env and provide your CryptoCompare API key
+CRYPTOCOMPARE_API_KEY=your_key_here
 
 # --- Thresholds ---
 RSI_OVERBOUGHT=70
@@ -38,5 +38,5 @@ ENABLE_CRON=false
 # Base URL of the running API (used by the cron job)
 API_BASE_URL=http://localhost:3000
 
-# Cache duration in minutes for Twelve Data requests
+# Cache duration in minutes for API requests
 CACHE_TTL_MINUTES=60

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitcoin Notification API
 
-This project provides a simple Express server that fetches current Bitcoin data from the Twelve Data API.
+This project provides a simple Express server that fetches current Bitcoin data from the CryptoCompare API.
 
 ## Setup
 
@@ -10,7 +10,7 @@ This project provides a simple Express server that fetches current Bitcoin data 
 npm install
 ```
 
-2. Create a `.env` file based on `.env.example` and set your `TWELVE_DATA_API_KEY`:
+2. Create a `.env` file based on `.env.example` and set your `CRYPTOCOMPARE_API_KEY`:
 
 ```bash
 cp .env.example .env
@@ -19,7 +19,7 @@ cp .env.example .env
 
 The `.env` file also allows configuration of `CACHE_TTL_MINUTES` which
 controls how long API responses are cached. Increasing this value reduces
-the number of requests made to Twelve Data.
+the number of requests made to CryptoCompare.
 
 3. Start the server:
 
@@ -73,7 +73,7 @@ The response contains multiple indicators along with the configured strategy thr
 }
 ```
 
-If one or more indicators fail to load, the response will still include the available indicators and an `errors` array describing which ones failed.
+All indicators are calculated locally from the OHLCV data returned by CryptoCompare.
 
 ## Deploying to Render
 
@@ -83,7 +83,7 @@ to [Render](https://render.com). To deploy:
 1. Push your fork of this repository to a GitHub account.
 2. Create a new **Web Service** on Render and point it at your repository.
 3. When prompted, Render will detect `render.yaml` and automatically configure
-   the service. Provide your `TWELVE_DATA_API_KEY` in the service's environment
+   the service. Provide your `CRYPTOCOMPARE_API_KEY` in the service's environment
    settings.
 
 Render will then build and start the server using the commands defined in
@@ -91,7 +91,7 @@ Render will then build and start the server using the commands defined in
 
 ## Logging
 
-Each API request to Twelve Data is logged to the console. Successful requests
+Each API request to CryptoCompare is logged to the console. Successful requests
 are prefixed with `[API]` and cache hits with `[CACHE]`. Errors are logged with
 `[API]` followed by the error message so they can be viewed in platforms like
 Railway or Render.
@@ -99,7 +99,7 @@ Railway or Render.
 ## Background Cron Job
 
 If `ENABLE_CRON=true` is set in the environment, the server will run a
-background task every 12 hours. This task fetches `/api/btc-indicators`,
-evaluates the trading signal and logs the result. When email credentials are
-configured and `ENABLE_NOTIFICATIONS=true`, alert emails are sent on BUY or
-SELL signals.
+background task every 12 hours. This task pulls recent market data from
+CryptoCompare, evaluates the trading signal and logs the result. When email
+credentials are configured and `ENABLE_NOTIFICATIONS=true`, alert emails are
+sent on BUY or SELL signals.

--- a/cron/evaluateAndLog.js
+++ b/cron/evaluateAndLog.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { RSI, MACD, EMA, SMA, BollingerBands, ADX, CCI, Stochastic } from 'technicalindicators';
 import { evaluateSignal } from '../signalEvaluator.js';
 import { sendEmail } from '../notifier.js';
 import dotenv from 'dotenv';
@@ -12,6 +13,54 @@ const trackedAssets = [
   { symbol: 'ADA/USD', name: 'Cardano' }
 ];
 
+function getSymbolPair(asset) {
+  const [fsym, tsym] = asset.split('/');
+  return { fsym, tsym };
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchOhlcv(fsym, tsym) {
+  const apiKey = process.env.CRYPTOCOMPARE_API_KEY;
+  if (!apiKey) {
+    throw new Error('CRYPTOCOMPARE_API_KEY is not configured');
+  }
+  const url = `https://min-api.cryptocompare.com/data/v2/histohour?fsym=${fsym}&tsym=${tsym}&limit=50&api_key=${apiKey}`;
+  const res = await axios.get(url);
+  if (!res.data || !res.data.Data || !Array.isArray(res.data.Data.Data)) {
+    throw new Error('Invalid data from CryptoCompare');
+  }
+  return res.data.Data.Data;
+}
+
+function calculateIndicators(candles) {
+  const closes = candles.map((c) => c.close);
+  const highs = candles.map((c) => c.high);
+  const lows = candles.map((c) => c.low);
+
+  const rsiArr = RSI.calculate({ values: closes, period: 14 });
+  const macdArr = MACD.calculate({ values: closes, fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, SimpleMAOscillator: false, SimpleMASignal: false });
+  const ema20Arr = EMA.calculate({ period: 20, values: closes });
+  const sma50Arr = SMA.calculate({ period: 50, values: closes });
+  const bbArr = BollingerBands.calculate({ period: 20, values: closes, stdDev: 2 });
+  const adxArr = ADX.calculate({ close: closes, high: highs, low: lows, period: 14 });
+  const cciArr = CCI.calculate({ high: highs, low: lows, close: closes, period: 20 });
+  const stochArr = Stochastic.calculate({ high: highs, low: lows, close: closes, period: 14, signalPeriod: 3 });
+
+  const price = closes[closes.length - 1];
+
+  return {
+    rsi: { values: [{ rsi: rsiArr[rsiArr.length - 1] }] },
+    macd: { values: [{ macd: macdArr[macdArr.length - 1]?.MACD, macd_signal: macdArr[macdArr.length - 1]?.signal }] },
+    ema20: { values: [{ ema: ema20Arr[ema20Arr.length - 1] }] },
+    sma50: { values: [{ sma: sma50Arr[sma50Arr.length - 1] }] },
+    bbands: { values: [{ real: price, lower_band: bbArr[bbArr.length - 1]?.lower, upper_band: bbArr[bbArr.length - 1]?.upper }] },
+    stochastic: { values: [{ slow_k: stochArr[stochArr.length - 1]?.k, slow_d: stochArr[stochArr.length - 1]?.d }] },
+    adx: { values: [{ adx: adxArr[adxArr.length - 1]?.adx }] },
+    cci: { values: [{ cci: cciArr[cciArr.length - 1] }] }
+  };
+}
+
 async function run() {
   console.log(`[CRON START] Evaluating ${trackedAssets.length} assets`);
   let buy = 0;
@@ -21,10 +70,12 @@ async function run() {
   for (const asset of trackedAssets) {
     console.log(`[CRON] Checking ${asset.name} at ${new Date().toISOString()}`);
     try {
-      const url = `${process.env.API_BASE_URL}/api/btc-indicators?symbol=${encodeURIComponent(asset.symbol)}`;
-      const res = await axios.get(url);
-      const result = evaluateSignal(res.data);
+      const { fsym, tsym } = getSymbolPair(asset.symbol);
+      const candles = await fetchOhlcv(fsym, tsym);
+      const indicators = calculateIndicators(candles);
+      const result = evaluateSignal(indicators);
       console.log(`[SIGNAL][${asset.name}] ${result.signal} - ${result.reason.join(', ')}`);
+
       if (result.signal === 'BUY') buy++;
       else if (result.signal === 'SELL') sell++;
       else hold++;
@@ -37,6 +88,8 @@ async function run() {
       console.error(`[CRON ERROR][${asset.name}] ${error.message}`);
       hold++;
     }
+
+    await delay(1500);
   }
 
   console.log(`[CRON COMPLETE] ${trackedAssets.length} assets checked, ${buy} BUY, ${sell} SELL, ${hold} HOLD`);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^1.6.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "nodemailer": "^6.9.7"
+    "nodemailer": "^6.9.7",
+    "technicalindicators": "^3.1.0"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     buildCommand: 'npm install'
     startCommand: 'npm start'
     envVars:
-      - key: TWELVE_DATA_API_KEY
+      - key: CRYPTOCOMPARE_API_KEY
         sync: false
   - type: worker
     name: bitcoin-notification-cron


### PR DESCRIPTION
## Summary
- move market data fetching from Twelve Data to CryptoCompare
- compute indicators locally with `technicalindicators`
- refactor cron job to pull OHLCV from CryptoCompare
- update environment and Render config for new API key
- document CryptoCompare setup in README

## Testing
- `npm install` *(fails: no network)*