### PR TITLE
Fix cron interval and add basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ if (process.env.ENABLE_CRON === 'true') {
     });
   };
   runJob();
-  cronInterval = setInterval(runJob, 12 * 60 * 60 * 1000);
+  cronInterval = setInterval(runJob, 30 * 60 * 1000);
   aliveInterval = setInterval(() => {
     console.log(`[DEBUG] App is alive at ${new Date().toISOString()}`);
   }, 60 * 1000);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "axios": "^1.6.5",

--- a/tests/signalEvaluator.test.js
+++ b/tests/signalEvaluator.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateSignal } from '../signalEvaluator.js';
+
+// Basic sanity check for BUY signal when RSI below threshold
+
+test('evaluateSignal returns BUY when RSI below oversold threshold', () => {
+  const data = {
+    rsi: { values: [{ rsi: 25 }] },
+    macd: { values: [{ macd: 0, macd_signal: 0 }] },
+    bbands: { values: [{ real: 100, lower_band: 50, upper_band: 150 }] },
+    cci: { values: [{ cci: -100 }] },
+    adx: { values: [{ adx: 50 }] },
+    stochastic: { values: [{ slow_k: 10, slow_d: 10 }] },
+    config: {
+      buyRules: {
+        useRsi: true,
+        rsiOversold: 30,
+        useMacd: false,
+        useBbands: false,
+        useCci: false,
+        useAdx: false,
+        useStoch: false
+      },
+      sellRules: {}
+    }
+  };
+
+  const result = evaluateSignal(data);
+  assert.equal(result.signal, 'BUY');
+});


### PR DESCRIPTION
## Summary
- ensure `node --test` runs via npm script
- add initial test for `evaluateSignal`
- adjust cron schedule to run every 30 minutes
- ignore `node_modules`

## Testing
- `npm test`
